### PR TITLE
Resolve infinite loop when parsing an invalid bash file

### DIFF
--- a/gentoopm/bash/bashserver.py
+++ b/gentoopm/bash/bashserver.py
@@ -57,7 +57,11 @@ class BashServer(BashParser):
 		f = self._bashproc.stdout
 		buf = b' '
 		while not buf.endswith(b'\0'):
-			buf += f.read(1)
+			x = f.read(1)
+			if len(x) < 1:
+				# end-of-file
+				raise InvalidBashCodeError()
+			buf += x
 		return buf[1:-1].decode('utf-8')
 
 	def _write(self, *cmds):

--- a/gentoopm/bash/bashserver.py
+++ b/gentoopm/bash/bashserver.py
@@ -37,20 +37,18 @@ class BashServer(BashParser):
 		self._bashproc.communicate()
 
 	def load_file(self, envf):
-		f = tempfile.NamedTemporaryFile('w+b')
-		shutil.copyfileobj(envf, f)
-		f.flush()
+		with tempfile.NamedTemporaryFile('w+b') as f:
+			shutil.copyfileobj(envf, f)
+			f.flush()
 
-		self._write('exit 0',
-				'bash -n %s &>/dev/null && printf "OK\\0" || printf "FAIL\\0"' % repr(f.name))
-		resp = self._read1()
+			self._write('exit 0',
+					'bash -n %s &>/dev/null && printf "OK\\0" || printf "FAIL\\0"' % repr(f.name))
+			resp = self._read1()
 
-		if resp == 'OK':
-			self._write('source %s &>/dev/null; printf "DONE\\0"' % repr(f.name))
-		if self._read1() != 'DONE':
-			raise AssertionError('Sourcing unexpected caused stdout output')
-
-		f.close()
+			if resp == 'OK':
+				self._write('source %s &>/dev/null; printf "DONE\\0"' % repr(f.name))
+			if self._read1() != 'DONE':
+				raise AssertionError('Sourcing unexpected caused stdout output')
 
 		if resp != 'OK':
 			raise InvalidBashCodeError()

--- a/gentoopm/bash/bashserver.py
+++ b/gentoopm/bash/bashserver.py
@@ -43,15 +43,14 @@ class BashServer(BashParser):
 
 			self._write('exit 0',
 					'bash -n %s &>/dev/null && printf "OK\\0" || printf "FAIL\\0"' % repr(f.name))
-			resp = self._read1()
 
-			if resp == 'OK':
-				self._write('source %s &>/dev/null; printf "DONE\\0"' % repr(f.name))
+			if self._read1() != 'OK':
+				raise InvalidBashCodeError()
+
+			self._write('source %s &>/dev/null; printf "DONE\\0"' % repr(f.name))
+
 			if self._read1() != 'DONE':
 				raise AssertionError('Sourcing unexpected caused stdout output')
-
-		if resp != 'OK':
-			raise InvalidBashCodeError()
 
 	def _read1(self):
 		f = self._bashproc.stdout


### PR DESCRIPTION
These changes prevent an infinite read() loop when bash exits unexpectedly. See the individual commit messages for details.