### PR TITLE
pkg: Support upstream metadata

### DIFF
--- a/gentoopm/basepm/pkg.py
+++ b/gentoopm/basepm/pkg.py
@@ -1,4 +1,5 @@
 # (c) 2011-2024 Michał Górny <mgorny@gentoo.org>
+# (c) 2024 Anna <cyber@sysrq.in>
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import os.path
@@ -14,6 +15,7 @@ from ..util import (
 
 from .atom import PMAtom, PMPackageKey
 from .environ import PMPackageEnvironment
+from gentoopm.basepm.upstream import PMUpstream
 
 PMPackageState = EnumTuple("PMPackageState", "installable", "installed")
 
@@ -416,6 +418,13 @@ class PMInstallablePackage(PMPackage):
         @type: tuple(L{PMPackageMaintainer})/C{None}
         """
         pass
+
+    @property
+    @abstractmethod
+    def upstream(self) -> PMUpstream:
+        """
+        Get the package upstream metadata.
+        """
 
     @abstractproperty
     def repo_masked(self):

--- a/gentoopm/basepm/upstream.py
+++ b/gentoopm/basepm/upstream.py
@@ -1,0 +1,190 @@
+# (c) 2024 Anna <cyber@sysrq.in>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import typing
+from abc import abstractmethod
+from collections.abc import Sequence
+from enum import Enum
+
+from ..util import (
+    ABCObject,
+    StringCompat
+)
+
+
+class PMUpstreamMaintainerStatus(Enum):
+    """
+    Maintainer status enumeration.
+    """
+
+    UNKNOWN = None
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+
+
+class PMUpstreamMaintainer(ABCObject, StringCompat):
+    """
+    A base class for an upstream maintainer.
+    """
+
+    _name: str
+    _email: typing.Optional[str]
+    _status: PMUpstreamMaintainerStatus
+
+    def __new__(cls, name: str, email: typing.Optional[str] = None,
+                status: PMUpstreamMaintainerStatus = PMUpstreamMaintainerStatus.UNKNOWN):
+        """
+        Instantiate the actual string. Requires other props prepared
+        beforehand.
+
+        @param email: maintainer's e-mail address
+        @param name: maintainer's name
+        @param status: maintainer's activity status
+        """
+
+        parts = [name]
+        if email is not None:
+            parts.append(f"<{email}>")
+
+        ret = StringCompat.__new__(cls, " ".join(parts))
+        ret._name = name
+        ret._email = email
+        ret._status = status
+        return ret
+
+    @property
+    def name(self) -> str:
+        """
+        Maintainer's name.
+        """
+        return self._name
+
+    @property
+    def email(self) -> typing.Optional[str]:
+        """
+        Maintainer's e-mail address.
+        """
+        return self._email
+
+    @property
+    def status(self) -> PMUpstreamMaintainerStatus:
+        """
+        Maintainer's activity status.
+        """
+        return self._status
+
+
+class PMUpstreamDoc(ABCObject, StringCompat):
+    """
+    A base class for a link to the upstream documentation.
+    """
+
+    _url: str
+    _lang: str
+
+    def __new__(cls, url: str, lang: str = "en"):
+        """
+        Instantiate the actual string. Requires other props prepared
+        beforehand.
+
+        @param url: documentation URL
+        @param lang: documentation language
+        """
+
+        ret = StringCompat.__new__(cls, url)
+        ret._url = url
+        ret._lang = lang
+        return ret
+
+    @property
+    def url(self) -> str:
+        """
+        Documentation URL.
+        """
+        return self._url
+
+    @property
+    def lang(self) -> str:
+        """
+        Documentation language.
+        """
+        return self._lang
+
+
+class PMUpstreamRemoteID(ABCObject, StringCompat):
+    """
+    A base class for an upstream remote-id.
+    """
+
+    _name: str
+    _site: str
+
+    def __new__(cls, name: str, site: str):
+        """
+        Instantiate the actual string. Requires other props prepared
+        beforehand.
+
+        @param name: package's identifier on the site
+        @param site: type of package identification tracker
+        """
+
+        ret = StringCompat.__new__(cls, f"{site}: {name}")
+        ret._name = name
+        ret._site = site
+        return ret
+
+    @property
+    def name(self) -> str:
+        """
+        Package's identifier on the site.
+        """
+        return self._name
+
+    @property
+    def site(self) -> str:
+        """
+        Type of package identification tracker.
+        """
+        return self._site
+
+
+class PMUpstream(ABCObject):
+    """
+    An abstract class representing upstream metadata.
+    """
+
+    @property
+    def bugs_to(self) -> typing.Optional[str]:
+        """
+        Location where to report bugs (may also be an email address prefixed
+        with "mailto:").
+        """
+        raise NotImplementedError
+
+    @property
+    def changelog(self) -> typing.Optional[str]:
+        """
+        URL where the upstream changelog can be found.
+        """
+        raise NotImplementedError
+
+    @property
+    def docs(self) -> Sequence[PMUpstreamDoc]:
+        """
+        URLs where the location of the upstream documentation can be found.
+        """
+        raise NotImplementedError
+
+    @property
+    def maintainers(self) -> Sequence[PMUpstreamMaintainer]:
+        """
+        Upstream maintainers.
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def remote_ids(self) -> Sequence[PMUpstreamRemoteID]:
+        """
+        Package's identifiers on third-party trackers.
+        """

--- a/gentoopm/tests/test_pkg.py
+++ b/gentoopm/tests/test_pkg.py
@@ -1,4 +1,5 @@
 # (c) 2011-2024 Michał Górny <mgorny@gentoo.org>
+# (c) 2024 Anna <cyber@sysrq.in>
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import pytest
@@ -123,6 +124,46 @@ def test_no_maintainers(subslotted_pkg):
     if subslotted_pkg.maintainers is None:
         pytest.skip("maintainers not supported")
     assert list(subslotted_pkg.maintainers) == []
+
+
+def test_upstream(stack_pkg):
+    assert (upstream := stack_pkg.upstream) is not None
+    try:
+        assert upstream.bugs_to == "https://bugs.example.com/enter_bug.cgi"
+        assert upstream.changelog == "https://example.com/changelog.txt"
+    except NotImplementedError:
+        pytest.skip("upstream.bugs_to not implemented")
+
+
+def test_upstream_docs(stack_pkg):
+    assert (upstream := stack_pkg.upstream) is not None
+    try:
+        assert [(d.url, d.lang) for d in upstream.docs] == [
+            ("https://docs.example.com/en/", "en"),
+            ("https://docs.example.com/pl/", "pl"),
+        ]
+    except NotImplementedError:
+        pytest.skip("upstream.docs not implemented")
+
+
+def test_upstream_maintainers(stack_pkg):
+    assert (upstream := stack_pkg.upstream) is not None
+    try:
+        assert [(d.name, d.email, d.status) for d in upstream.maintainers] == [
+            ("Alice", None, "active"),
+            ("Bob", "bob@example.com", "inactive"),
+            ("Carol", "carol@example.com", None),
+        ]
+    except NotImplementedError:
+        pytest.skip("upstream.maintainers not implemented")
+
+
+def test_upstream_remote_id(stack_pkg):
+    assert (upstream := stack_pkg.upstream) is not None
+    assert [(r.site, r.name) for r in upstream.remote_ids] == [
+        ("github", "projg2/gentoopm"),
+        ("pypi", "gentoopm")
+    ]
 
 
 def test_repo_masked(pm):

--- a/test-root/usr/portage/a/single/metadata.xml
+++ b/test-root/usr/portage/a/single/metadata.xml
@@ -9,4 +9,23 @@
 		<email>test2@example.com</email>
 		<name>Michał Górny</name>
 	</maintainer>
+	<upstream>
+		<bugs-to>https://bugs.example.com/enter_bug.cgi</bugs-to>
+		<changelog>https://example.com/changelog.txt</changelog>
+		<doc>https://docs.example.com/en/</doc>
+		<doc lang="pl">https://docs.example.com/pl/</doc>
+		<maintainer status="active">
+			<name>Alice</name>
+		</maintainer>
+		<maintainer status="inactive">
+			<name>Bob</name>
+			<email>bob@example.com</email>
+		</maintainer>
+		<maintainer>
+			<name>Carol</name>
+			<email>carol@example.com</email>
+		</maintainer>
+		<remote-id type="github">projg2/gentoopm</remote-id>
+		<remote-id type="pypi">gentoopm</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Fully supported only for Portage, pkgcore can return only remote-ids.
